### PR TITLE
PayU Latam: Fix bug in confirmation page

### DIFF
--- a/pages/confirmation.php
+++ b/pages/confirmation.php
@@ -76,7 +76,6 @@ else
 $cart = new Cart((int)$reference_code);
 if (Tools::strtoupper($signature) == Tools::strtoupper($signature_md5))
 {
-	$this->context = Context::getContext();
 	$state = 'PAYU_OS_FAILED';
 	if ($transaction_state == 6 && $pol_response_code == 5)
 		$state = 'PAYU_OS_FAILED';
@@ -126,8 +125,8 @@ if (Tools::strtoupper($signature) == Tools::strtoupper($signature_md5))
 			else
 			{
 				$customer = new Customer((int)$cart->id_customer);
-				$this->context->customer = $customer;
-				$this->context->currency = $currency_cart;
+				Context::getContext()->customer = $customer;
+				Context::getContext()->currency = $currency_cart;
 
 				$payulatam->validateOrder((int)$cart->id, (int)Configuration::get($state), (float)$cart->getordertotal(true), 'PayU Latam', null, array(), (int)$currency_cart->id, false, $customer->secure_key);
 				Configuration::updateValue('PAYULATAM_CONFIGURATION_OK', true);


### PR DESCRIPTION
I watched the issue http://forge.prestashop.com/browse/PNM-2903 and searching about it but I not found a solution. I found this article http://addons-modules.com/store/en/content/31--why-the-cart-is-not-cleared-after-payment- and I could check the behavior therefore I would say it's not a bug but I'm not sure.
